### PR TITLE
Alterada validacao de valor preenchido para propriedade opcional exis…

### DIFF
--- a/src/Factories/Traits/TraitS2399.php
+++ b/src/Factories/Traits/TraitS2399.php
@@ -673,12 +673,14 @@ trait TraitS2399
             !empty($this->std->infotsvtermino->mtvdesligtsv) ? $this->std->infotsvtermino->mtvdesligtsv : null,
             false
         );
-        $this->dom->addChild(
-            $infoTSVTermino,
-            "pensAlim",
-            !empty($this->std->infotsvtermino->pensalim) ? $this->std->infotsvtermino->pensalim : null,
-            false
-        );
+        if (isset($this->std->infotsvtermino->pensalim)) {
+            $this->dom->addChild(
+                $infoTSVTermino,
+                "pensAlim",
+                $this->std->infotsvtermino->pensalim,
+                false
+            );
+        }
         $this->dom->addChild(
             $infoTSVTermino,
             "percAliment",


### PR DESCRIPTION
Alterada a validacao de valor preenchido para a existencia da propriedade opcional do objeo, pois o valor 0 é considerado valor nao preenchido no metodo empty() 